### PR TITLE
Add past time rules: T ago

### DIFF
--- a/rules/en/en.go
+++ b/rules/en/en.go
@@ -9,6 +9,7 @@ var All = []rules.Rule{
 	Hour(rules.Override),
 	HourMinute(rules.Override),
 	Deadline(rules.Override),
+	PastTime(rules.Override),
 }
 
 var WEEKDAY_OFFSET = map[string]int{

--- a/rules/en/past_time.go
+++ b/rules/en/past_time.go
@@ -1,0 +1,107 @@
+package en
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/AlekSi/pointer"
+	"github.com/olebedev/when/rules"
+	"github.com/pkg/errors"
+)
+
+func PastTime(s rules.Strategy) rules.Rule {
+	overwrite := s == rules.Override
+
+	return &rules.F{
+		RegExp: regexp.MustCompile(
+			"(?i)(?:\\W|^)\\s*" +
+				"(" + INTEGER_WORDS_PATTERN + "|[0-9]+|an?(?:\\s*few)?|half(?:\\s*an?)?)\\s*" +
+				"(seconds?|min(?:ute)?s?|hours?|days?|weeks?|months?|years?) (ago)\\s*" +
+				"(?:\\W|$)"),
+		Applier: func(m *rules.Match, c *rules.Context, o *rules.Options, ref time.Time) (bool, error) {
+
+			numStr := strings.TrimSpace(m.Captures[0])
+
+			var num int
+			var err error
+
+			if n, ok := INTEGER_WORDS[numStr]; ok {
+				num = n
+			} else if numStr == "a" || numStr == "an" {
+				num = 1
+			} else if strings.Contains(numStr, "few") {
+				num = 3
+			} else if strings.Contains(numStr, "half") {
+				// pass
+			} else {
+				num, err = strconv.Atoi(numStr)
+				if err != nil {
+					return false, errors.Wrapf(err, "convert '%s' to int", numStr)
+				}
+			}
+
+			exponent := strings.TrimSpace(m.Captures[1])
+
+			if !strings.Contains(numStr, "half") {
+				switch {
+				case strings.Contains(exponent, "second"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(time.Duration(num) * time.Second)
+					}
+				case strings.Contains(exponent, "min"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(time.Duration(num) * time.Minute)
+					}
+				case strings.Contains(exponent, "hour"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(time.Duration(num) * time.Hour)
+					}
+				case strings.Contains(exponent, "day"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(time.Duration(num) * 24 * time.Hour)
+					}
+				case strings.Contains(exponent, "week"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(time.Duration(num) * 7 * 24 * time.Hour)
+					}
+				case strings.Contains(exponent, "month"):
+					if c.Month == nil || overwrite {
+						c.Month = pointer.ToInt((int(ref.Month()) - num) % 12)
+					}
+				case strings.Contains(exponent, "year"):
+					if c.Year == nil || overwrite {
+						c.Year = pointer.ToInt(ref.Year() - num)
+					}
+				}
+			} else {
+				switch {
+				case strings.Contains(exponent, "hour"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(30 * time.Minute)
+					}
+				case strings.Contains(exponent, "day"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(12 * time.Hour)
+					}
+				case strings.Contains(exponent, "week"):
+					if c.Duration == 0 || overwrite {
+						c.Duration = -(7 * 12 * time.Hour)
+					}
+				case strings.Contains(exponent, "month"):
+					if c.Duration == 0 || overwrite {
+						// 2 weeks
+						c.Duration = -(14 * 24 * time.Hour)
+					}
+				case strings.Contains(exponent, "year"):
+					if c.Month == nil || overwrite {
+						c.Month = pointer.ToInt((int(ref.Month()) - 6) % 12)
+					}
+				}
+			}
+
+			return true, nil
+		},
+	}
+}

--- a/rules/en/past_time_test.go
+++ b/rules/en/past_time_test.go
@@ -1,0 +1,33 @@
+package en_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/olebedev/when"
+	"github.com/olebedev/when/rules"
+	"github.com/olebedev/when/rules/en"
+)
+
+func TestPastTime(t *testing.T) {
+	fixt := []Fixture{
+		{"half an hour ago", 0, "half an hour ago", -(time.Hour / 2)},
+		{"1 hour ago", 0, "1 hour ago", -(time.Hour)},
+		{"5 minutes ago", 0, "5 minutes ago", -(time.Minute * 5)},
+		{"5 minutes ago I went to the zoo", 0, "5 minutes ago", -(time.Minute * 5)},
+		{"we did something 10 days ago.", 17, "10 days ago", -(10 * 24 * time.Hour)},
+		{"we did something five days ago.", 17, "five days ago", -(5 * 24 * time.Hour)},
+		{"we did something 5 days ago.", 17, "5 days ago", -(5 * 24 * time.Hour)},
+		{"5 seconds ago a car was moved", 0, "5 seconds ago", -(5 * time.Second)},
+		{"two weeks ago", 0, "two weeks ago", -(14 * 24 * time.Hour)},
+		{"a month ago", 0, "a month ago", -(31 * 24 * time.Hour)},
+		{"a few months ago", 0, "a few months ago", -(92 * 24 * time.Hour)},
+		{"one year ago", 0, "one year ago", -(365 * 24 * time.Hour)},
+		{"a week ago", 0, "a week ago", -(7 * 24 * time.Hour)},
+	}
+
+	w := when.New(nil)
+	w.Add(en.PastTime(rules.Skip))
+
+	ApplyFixtures(t, "en.PastTime", w, fixt)
+}


### PR DESCRIPTION
This adds english rules for writing "T ago". The commit means that the
following examples should work:

5 minutes ago
2 hours ago
a month ago
half a month ago
etc.

It does not cover more complex rules such as "1 year ago tomorrow".

Let me know if there is anything that needs updating.

Thanks!