### PR TITLE
Truncate "10pm" to "10:00:00" as opposed to "10:00:12" (current second)

### DIFF
--- a/rules/en/hour.go
+++ b/rules/en/hour.go
@@ -54,6 +54,7 @@ func Hour(s rules.Strategy) rules.Rule {
 			}
 
 			c.Minute = &zero
+			c.Second = &zero
 			return true, nil
 		},
 	}

--- a/rules/en/hour_minute.go
+++ b/rules/en/hour_minute.go
@@ -75,6 +75,8 @@ func HourMinute(s rules.Strategy) rules.Rule {
 				}
 				c.Hour = &hour
 			}
+			seconds := 0 // Truncate seconds
+			c.Second = &seconds
 
 			return true, nil
 		},


### PR DESCRIPTION
Thanks for the great library. I have no illusions of this getting merged (since the lib seems unmaintained by now), but this annoyed me enough to create a PR :-)

Currently "10pm" is expanded to "10:00:x" with x being the current second. So if it's 8:23:12pm right now and you say "10pm", it'll be "10:00:12", which is not really what the user expects. 

I forked it and made keep this small change in a tag. You can use it like this:

```
replace github.com/olebedev/when => github.com/binwiederhier/when v0.0.1-binwiederhier2
```