### PR TITLE
Add common Dutch expressions for day in last or next week, fixes #44

### DIFF
--- a/rules/nl/nl_test.go
+++ b/rules/nl/nl_test.go
@@ -1,9 +1,10 @@
 package nl_test
 
 import (
-	"github.com/olebedev/when/rules/nl"
 	"testing"
 	"time"
+
+	"github.com/olebedev/when/rules/nl"
 
 	"github.com/olebedev/when"
 	"github.com/stretchr/testify/require"
@@ -51,12 +52,15 @@ func TestAll(t *testing.T) {
 
 	// complex cases
 	fixt := []Fixture{
+		{"vorige week zondag om 10:00", 0, "vorige week zondag om 10:00", ((-3 * 24) + 10) * time.Hour},
 		{"vanavond om 23:10", 0, "vanavond om 23:10", (23 * time.Hour) + (10 * time.Minute)},
 		{"op vrijdagmiddag", 3, "vrijdagmiddag", ((2 * 24) + 15) * time.Hour},
 		{"komende dinsdag om 14:00", 0, "komende dinsdag om 14:00", ((6 * 24) + 14) * time.Hour},
 		{"komende dinsdag 2 uur 's middags", 0, "komende dinsdag 2 uur 's middags", ((6 * 24) + 14) * time.Hour},
 		{"komende woensdag om 14:25", 0, "komende woensdag om 14:25", (((7 * 24) + 14) * time.Hour) + (25 * time.Minute)},
 		{"om 11 uur afgelopen dinsdag", 3, "11 uur afgelopen dinsdag", -13 * time.Hour},
+		{"volgende week dinsdag om 18:15", 0, "volgende week dinsdag om 18:15", (((6 * 24) + 18) * time.Hour) + (15 * time.Minute)},
+		{"volgende week vrijdag", 0, "volgende week vrijdag", (9 * 24) * time.Hour},
 	}
 
 	ApplyFixtures(t, "nl.All...", w, fixt)

--- a/rules/nl/weekday_test.go
+++ b/rules/nl/weekday_test.go
@@ -1,23 +1,40 @@
 package nl_test
 
 import (
-	"github.com/olebedev/when/rules/nl"
 	"testing"
 	"time"
+
+	"github.com/olebedev/when/rules/nl"
 
 	"github.com/olebedev/when"
 	"github.com/olebedev/when/rules"
 )
 
 func TestWeekday(t *testing.T) {
-	// current is Friday
+	// current is Wednesday
 	fixt := []Fixture{
+		// past week
+		{"vorige week maandag", 0, "vorige week maandag", -(9 * 24 * time.Hour)},
+		{"vorige week dinsdag", 0, "vorige week dinsdag", -(8 * 24 * time.Hour)},
+		{"vorige week woensdag", 0, "vorige week woensdag", -(7 * 24 * time.Hour)},
+		{"vorige week donderdag", 0, "vorige week donderdag", -(6 * 24 * time.Hour)},
+		{"vorige week vrijdag", 0, "vorige week vrijdag", -(5 * 24 * time.Hour)},
+		{"vorige week zaterdag", 0, "vorige week zaterdag", -(4 * 24 * time.Hour)},
+		{"vorige week zondag", 0, "vorige week zondag", -(3 * 24 * time.Hour)},
 		// past/last
 		{"doe het voor afgelopen maandag", 13, "afgelopen maandag", -(2 * 24 * time.Hour)},
 		{"afgelopen zaterdag", 0, "afgelopen zaterdag", -(4 * 24 * time.Hour)},
 		{"afgelopen vrijdag", 0, "afgelopen vrijdag", -(5 * 24 * time.Hour)},
 		{"afgelopen woensdag", 0, "afgelopen woensdag", -(7 * 24 * time.Hour)},
 		{"afgelopen dinsdag", 0, "afgelopen dinsdag", -(24 * time.Hour)},
+		// next week
+		{"volgende week maandag", 0, "volgende week maandag", 5 * 24 * time.Hour},
+		{"volgende week dinsdag", 0, "volgende week dinsdag", 6 * 24 * time.Hour},
+		{"volgende week woensdag", 0, "volgende week woensdag", 7 * 24 * time.Hour},
+		{"volgende week donderdag", 0, "volgende week donderdag", 8 * 24 * time.Hour},
+		{"volgende week vrijdag", 0, "volgende week vrijdag", 9 * 24 * time.Hour},
+		{"volgende week zaterdag", 0, "volgende week zaterdag", 10 * 24 * time.Hour},
+		{"volgende week zondag", 0, "volgende week zondag", 11 * 24 * time.Hour},
 		// next
 		{"komende dinsdag", 0, "komende dinsdag", 6 * 24 * time.Hour},
 		{"stuur me een bericht komende woensdag", 21, "komende woensdag", 7 * 24 * time.Hour},


### PR DESCRIPTION
I implemented common Dutch expressions for a day in the last week, for example "vorige week woensdag" which translates to "last week on wednesday". Or a day in the next week, like "volgende week zondag" which translates to "next week on sunday." This is commonly used and is different from "next sunday." If I say today (on a friday) that I will see you "volgende week zondag" I mean the sunday after next sunday. Although it is less commonly used, I also added "komende week" which means the same as "volgende week."

This fixes the issue described in https://github.com/olebedev/when/issues/44.