### PR TITLE
fix: no empty string matches

### DIFF
--- a/rules/rules.go
+++ b/rules/rules.go
@@ -74,7 +74,7 @@ func (f *F) Find(text string) *Match {
 		}
 	}
 
-	if len(m.Captures) == 0 {
+	if len(m.Captures) == 0 || m.Left == -1 {
 		return nil
 	}
 

--- a/rules/zh/exact_month_date.go
+++ b/rules/zh/exact_month_date.go
@@ -19,13 +19,17 @@ func ExactMonthDate(s rules.Strategy) rules.Rule {
 		RegExp: regexp.MustCompile("" +
 			"(?:\\b|^)" + // can't use \W here due to Chinese characters
 			"(?:" +
-			"(1[0-2]|[1-9]|" + MON_WORDS_PATTERN + ")" + "(?:\\s*)" +
-			"(月|-|/|\\.)" + "(?:\\s*)" +
+			"(1[0-2]|[1-9])" + "\\s*" + "(?:-|/|\\.)" + "\\s*" + "(1[0-9]|2[0-9]|3[0-1]|[1-9])" +
+			"|" +
+			"(?:" +
+			"(1[0-2]|[1-9]|" + MON_WORDS_PATTERN + ")" + "\\s*" +
+			"(月)" + "\\s*" +
 			")?" +
 			"(?:" +
-			"(1[0-9]|2[0-9]|3[0-1]|[1-9]|" + DAY_WORDS_PATTERN + ")" + "(?:\\s*)" +
-			"(日|号)?" +
-			")?",
+			"(1[0-9]|2[0-9]|3[0-1]|[1-9]|" + DAY_WORDS_PATTERN + ")" + "\\s*" +
+			"(日|号)" +
+			")?" +
+			")",
 		),
 
 		Applier: func(m *rules.Match, c *rules.Context, o *rules.Options, ref time.Time) (bool, error) {
@@ -38,14 +42,14 @@ func ExactMonthDate(s rules.Strategy) rules.Rule {
 			var dayInt = 1
 			var exist bool
 
-			if m.Captures[1] == "" && m.Captures[3] == "" {
+			if m.Captures[0] == "" && m.Captures[2] == "" && m.Captures[4] == "" {
 				return false, nil
 			}
 
-			if m.Captures[0] != "" {
-				monInt, exist = MON_WORDS[compressStr(m.Captures[0])]
+			if m.Captures[2] != "" {
+				monInt, exist = MON_WORDS[compressStr(m.Captures[2])]
 				if !exist {
-					mon, err := strconv.Atoi(m.Captures[0])
+					mon, err := strconv.Atoi(m.Captures[2])
 					if err != nil {
 						return false, nil
 					}
@@ -53,15 +57,28 @@ func ExactMonthDate(s rules.Strategy) rules.Rule {
 				}
 			}
 
-			if m.Captures[2] != "" {
-				dayInt, exist = DAY_WORDS[compressStr(m.Captures[2])]
+			if m.Captures[4] != "" {
+				dayInt, exist = DAY_WORDS[compressStr(m.Captures[4])]
 				if !exist {
-					day, err := strconv.Atoi(m.Captures[2])
+					day, err := strconv.Atoi(m.Captures[4])
 					if err != nil {
 						return false, nil
 					}
 					dayInt = day
 				}
+			}
+
+			if m.Captures[0] != "" && m.Captures[1] != "" {
+				mon, err := strconv.Atoi(m.Captures[0])
+				if err != nil {
+					return false, nil
+				}
+				day, err := strconv.Atoi(m.Captures[1])
+				if err != nil {
+					return false, nil
+				}
+				monInt = mon
+				dayInt = day
 			}
 
 			c.Month = &monInt

--- a/rules/zh/weekday_test.go
+++ b/rules/zh/weekday_test.go
@@ -1,12 +1,12 @@
 package zh_test
 
 import (
-	"github.com/olebedev/when/rules/zh"
 	"testing"
 	"time"
 
 	"github.com/olebedev/when"
 	"github.com/olebedev/when/rules"
+	"github.com/olebedev/when/rules/zh"
 )
 
 func TestWeekday(t *testing.T) {


### PR DESCRIPTION
# Fix an edge case

There will be a panic when `m.Left == -1`, this is the root cause of this issue.

The reason why `m.Left == -1` is due to the `exact_month_date` rule that returns an empty string for `这周三` (this Wednesday).

But simply fixing this issue will cause another issue ↓

# Fix Chinese `exact_month_date` rule

The previous regex will recognise `2下周天` as `2`.

- This is "a normal number `2` and `next Sunday`", which should be `next Sunday`, since `2` is meaningless here.
- A regex will match `2`, which is wrong.
- I separated the "number-only form" from the "number & Chinese character form" to fix this issue.
- To prevent the regex from returning an empty string, the "number-only form" should be placed first.

---

Close #47