### PR TITLE
Fix month parsing overflowing into the next month

### DIFF
--- a/rules/context.go
+++ b/rules/context.go
@@ -29,7 +29,16 @@ func (c *Context) Time(t time.Time) (time.Time, error) {
 	}
 
 	if c.Month != nil {
-		t = time.Date(t.Year(), time.Month(*c.Month), t.Day(),
+		month := time.Month(*c.Month)
+
+		// time.Date would normalize a day the target month lacks into the next
+		// one; clamp instead.
+		day := t.Day()
+		if last := daysIn(month, t.Year()); day > last {
+			day = last
+		}
+
+		t = time.Date(t.Year(), month, day,
 			t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
 	}
 
@@ -65,4 +74,9 @@ func (c *Context) Time(t time.Time) (time.Time, error) {
 	}
 
 	return t, nil
+}
+
+// daysIn returns the number of days in the given month of the given year.
+func daysIn(m time.Month, year int) int {
+	return time.Date(year, m+1, 0, 0, 0, 0, 0, time.UTC).Day()
 }

--- a/rules/en/exact_month_date_test.go
+++ b/rules/en/exact_month_date_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/olebedev/when"
 	"github.com/olebedev/when/rules"
 	"github.com/olebedev/when/rules/en"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExactMonthDate(t *testing.T) {
@@ -36,4 +37,33 @@ func TestExactMonthDate(t *testing.T) {
 	}
 
 	ApplyFixtures(t, "en.ExactMonthDate", w, fixtok)
+}
+
+// Parsed against the 31st, a shorter target month used to overflow into the
+// next one: "september 5th" resolved to the 5th of October.
+func TestExactMonthDateFromLongMonth(t *testing.T) {
+	w := when.New(nil)
+	w.Add(en.ExactMonthDate(rules.Override))
+
+	ref := time.Date(2016, time.October, 31, 0, 0, 0, 0, time.UTC)
+
+	fixt := []struct {
+		Text     string
+		Expected time.Time
+	}{
+		{"september 5th", time.Date(2016, time.September, 5, 0, 0, 0, 0, time.UTC)},
+		{"february 11", time.Date(2016, time.February, 11, 0, 0, 0, 0, time.UTC)},
+		{"1st of june", time.Date(2016, time.June, 1, 0, 0, 0, 0, time.UTC)},
+		// No day in the text: the reference day clamps to the month's last.
+		{"september", time.Date(2016, time.September, 30, 0, 0, 0, 0, time.UTC)},
+		// Months that do have a 31st keep the reference day untouched.
+		{"december", time.Date(2016, time.December, 31, 0, 0, 0, 0, time.UTC)},
+	}
+
+	for i, f := range fixt {
+		res, err := w.Parse(f.Text, ref)
+		require.Nil(t, err, "[en.ExactMonthDate] err #%d", i)
+		require.NotNil(t, res, "[en.ExactMonthDate] res #%d", i)
+		require.Equal(t, f.Expected, res.Time, "[en.ExactMonthDate] time #%d", i)
+	}
 }


### PR DESCRIPTION

## Problem

Fixes #12

## Problem

Parsing a bare month, or a month with a day, against a reference date whose day
does not exist in the target month resolves to the wrong month. With the 31st of
October as the reference date:

| input           | got        | expected   |
|-----------------|------------|------------|
| `september 5th` | 2016-10-05 | 2016-09-05 |
| `february 11`   | 2016-03-11 | 2016-02-11 |
| `1st of june`   | 2016-07-01 | 2016-06-01 |

This is why the issue reports "September" turning into October and why a later
comment reports February turning into March at the end of January: the bug only
shows up when the reference date is a day that the parsed month does not have,
which is also why it was not reproducible with an arbitrary fixed date.

The last comment in the thread asks whether this has already been fixed. It has
not - the results above come from a run against current master (faea3c4).

## Root cause

`rules/context.go`, the `c.Month` branch of `Context.Time` (lines 31-34 before
this change):

```go
if c.Month != nil {
    t = time.Date(t.Year(), time.Month(*c.Month), t.Day(),
        t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), t.Location())
}
```

The day passed to `time.Date` is `t.Day()`, still the day of the *reference*
date, because the parsed day is only applied further down in the same function
(the `c.Day` branch). `time.Date` normalizes out-of-range days, so October 31st
plus month September becomes October 1st, and the `c.Day` branch then applies
the parsed day to the already wrong month.

## Solution

Clamp the reference day to the last day the target month actually has before
switching the month. The parsed day, when the text carries one, still overwrites
it afterwards, so the ordering of the existing branches is untouched:

- when the text has a day (`september 5th`), the clamped value is a throwaway
  placeholder that only has to stay inside the target month;
- when the text has no day (`september`), the result is the last day of the
  month instead of a silent jump into the next one.

A small `daysIn` helper does the lookup with the usual `time.Date(y, m+1, 0)`
trick. No rule files were touched.

## How this was tested

Gate, on the fixed tree:


52 test cases pass, no pre-existing failures, `gofmt -l .` is clean.

New regression test `TestExactMonthDateFromLongMonth` in
`rules/en/exact_month_date_test.go`. The existing fixtures cannot catch this
bug: `ApplyFixtures` pins the reference date to 2016-01-06, and the 6th exists
in every month, so the overflow never triggers. The new test parses against
2016-10-31 instead and checks the resulting dates directly.

With the fix reverted and the test in place:

```
=== RUN   TestExactMonthDateFromLongMonth
    Error:      Not equal:
                expected: time.Date(2016, time.September, 5, 0, 0, 0, 0, time.UTC)
                actual  : time.Date(2016, time.October, 5, 0, 0, 0, 0, time.UTC)
    Messages:   [en.ExactMonthDate] time #0
--- FAIL: TestExactMonthDateFromLongMonth (0.00s)
```

With the fix applied:

```
=== RUN   TestExactMonthDateFromLongMonth
--- PASS: TestExactMonthDateFromLongMonth (0.00s)
```

Go 1.22.2.
